### PR TITLE
Remove same-psf warning for single channel

### DIFF
--- a/csbdeep/data/transform.py
+++ b/csbdeep/data/transform.py
@@ -248,7 +248,7 @@ def anisotropic_distortions(
                     ch = axes_dict(axes)['C']
                     n_channels = x.shape[ch]
                     # convolve with psf separately for every channel
-                    if _psf.shape[ch] == 1:
+                    if _psf.shape[ch] == 1 and n_channels > 1:
                         warnings.warn('applying same psf to every channel of the image.')
                     if _psf.shape[ch] in (1,n_channels):
                         x = np.stack([


### PR DESCRIPTION
I have single-channel inputs and get this warning all the time. 
It feels incorrect though, as a single-channel psf is the only option in that case, so adding a check to only warn when there's a choice.