### PR TITLE
Add BioImage.io Modelzoo export

### DIFF
--- a/csbdeep/io/modelzoo.py
+++ b/csbdeep/io/modelzoo.py
@@ -21,7 +21,7 @@ class Postprocessing(dict):
 
 
 class ZeroMeanUnitVariance(Preprocessing):
-    def __init__(self, mode: str, axes: str, mean: list[float], std: list[float]):
+    def __init__(self, mode, axes, mean, std):
         self.name = "Zero_mean_unit_variance"
         self.kwargs = {}
         self.kwargs.mode = mode
@@ -32,7 +32,7 @@ class ZeroMeanUnitVariance(Preprocessing):
 
 
 class ScaleLinear(Postprocessing):
-    def __init__(self, mode: str, axes: str):
+    def __init__(self, mode, axes):
         self.name = "Zero_mean_unit_variance"
         self.kwargs = {}
         self.kwargs.gain = mode
@@ -41,8 +41,8 @@ class ScaleLinear(Postprocessing):
 
 class ModelZooInput(dict):
 
-    def __init__(self, name: str, axes: str, data_type: type, data_range: list, halo: list, min: list, step: list,
-                 preprocessing: Preprocessing):
+    def __init__(self, name, axes, data_type, data_range, halo, min, step,
+                 preprocessing):
         self.name = name
         self.axes = axes
         self.data_type = data_type
@@ -55,7 +55,7 @@ class ModelZooInput(dict):
 
 
 class ModelZooOutput(dict):
-    def __init__(self, name: str, axes: str, offset: list, scale: list, reference_input: str, postprocessing: dict):
+    def __init__(self, name, axes, offset, scale, reference_input, postprocessing):
         self.name = name
         self.axes = axes
         self.shape = {}
@@ -66,7 +66,7 @@ class ModelZooOutput(dict):
 
 
 class ModelZooWeight(dict):
-    def __init__(self, weight_format: str, source: str, modelfile_name: str):
+    def __init__(self, weight_format, source, modelfile_name):
         self.weight_format = weight_format
         self.source = source
         with open(modelfile_name, "rb") as f:
@@ -76,13 +76,13 @@ class ModelZooWeight(dict):
 
 
 class ModelZooBaseData(dict):
-    def __init__(self, name: str, desc: str, cite: list[dict], authors: list[str], documentation: str,
-                 tags: list[str] = None,
-                 sample_input: list[str] = ['./sample_input.tif'], sample_output: list[str] = ['./sample_output.tif'],
-                 inputs: list[ModelZooInput] = [],
-                 outputs: list[ModelZooOutput] = [],
-                 weights: list[ModelZooWeight] = [], license: str = "bsd", format_version: str = "0.3.0",
-                 language: str = "python", framework: str = "tensorflow", config: dict = None):
+    def __init__(self, name, desc, cite, authors, documentation,
+                 tags=None,
+                 sample_input=['./sample_input.tif'], sample_output=['./sample_output.tif'],
+                 inputs=[],
+                 outputs=[],
+                 weights=[], license="bsd", format_version="0.3.0",
+                 language="python", framework="tensorflow", config = None):
         self.name = name
         self.desc = desc
         self.cite = cite
@@ -101,7 +101,7 @@ class ModelZooBaseData(dict):
         self.config = config
 
 
-def modelzoo_export(tf_model, folder_path, modelzoo_data: ModelZooBaseData, sample_input=None, sample_output=None,
+def modelzoo_export(tf_model, folder_path, modelzoo_data, sample_input=None, sample_output=None,
                     zip_name=None):
     export_SavedModel(tf_model, folder_path)
     if zip_name is None:

--- a/csbdeep/io/modelzoo.py
+++ b/csbdeep/io/modelzoo.py
@@ -113,25 +113,22 @@ class ModelZooBaseData(dict):
 def modelzoo_export(tf_model, folder_path, modelzoo_data, sample_input=None, sample_output=None,
                     zip_name=None):
     export_SavedModel(tf_model, folder_path)
-    modelzoo_weight = ModelZooWeight("tensorflow_saved_model_bundle", './variables/variables', str(zip_name))
-    modelzoo_data.weights = [modelzoo_weight]
     if zip_name is None:
-        zip_name = folder_path / 'export.bioimage.io.model.zip'
+        zip_name = folder_path + '/export.bioimage.io.model.zip'
     else:
         zip_name = Path(zip_name)
-    input_file = folder_path / 'sample_input.tif'
-    output_file = folder_path / 'sample_output.tif'
+    input_file = folder_path + '/sample_input.tif'
+    output_file = folder_path + '/sample_output.tif'
     imsave(input_file, sample_input)
     imsave(output_file, sample_output)
     modelzoo_data.test_inputs = [input_file]
     modelzoo_data.test_outputs = [output_file]
 
-    yml_file = folder_path / "model.yml"
+    yml_file = folder_path + '/model.yml'
     yaml = YAML(typ='rt')
     yaml.default_flow_style = False
     with open(yml_file, 'w', encoding='UTF-8') as outfile:
         yaml.dump(modelzoo_data, outfile)
-
 
     with ZipFile(zip_name, 'a') as myzip:
         myzip.write(yml_file, arcname=os.path.basename(yml_file))

--- a/csbdeep/io/modelzoo.py
+++ b/csbdeep/io/modelzoo.py
@@ -22,7 +22,7 @@ class Postprocessing(dict):
 
 class ZeroMeanUnitVariance(Preprocessing):
     def __init__(self, mode, axes, mean, std):
-        self.name = "Zero_mean_unit_variance"
+        self.name = "zero_mean_unit_variance"
         self.kwargs = {}
         self.kwargs.mode = mode
         self.kwargs.axes = axes
@@ -32,11 +32,12 @@ class ZeroMeanUnitVariance(Preprocessing):
 
 
 class ScaleLinear(Postprocessing):
-    def __init__(self, mode, axes):
-        self.name = "Zero_mean_unit_variance"
+    def __init__(self, gain, axes, offset):
+        self.name = "scale_linear"
         self.kwargs = {}
-        self.kwargs.gain = mode
-        self.kwargs.offset = axes
+        self.kwargs.gain = gain
+        self.kwargs.offset = offset
+        self.kwargs.axes = axes
 
 
 class ModelZooInput(dict):
@@ -66,60 +67,71 @@ class ModelZooOutput(dict):
 
 
 class ModelZooWeight(dict):
-    def __init__(self, weight_format, source, modelfile_name):
-        self.weight_format = weight_format
-        self.source = source
+    def __init__(self, weight_format, source, modelfile_name, authors, tag, tensorflowversion):
+        self[weight_format] = {}
+        self[weight_format]["authors"] = authors
+        self[weight_format]["source"] = source
         with open(modelfile_name, "rb") as f:
             bytes = f.read()
-            self.sha256 = sha256(bytes).hexdigest()
-        self.timestamp = datetime.now().isoformat()
+            self[weight_format]["sha256"] = sha256(bytes).hexdigest()
+        self[weight_format]["tag"] = tag
+        self[weight_format]["tensorflowversion"] = tensorflowversion
 
 
 class ModelZooBaseData(dict):
     def __init__(self, name, desc, cite, authors, documentation,
-                 tags=None,
+                 tags, dependencies, covers,
                  sample_input=['./sample_input.tif'], sample_output=['./sample_output.tif'],
                  inputs=[],
                  outputs=[],
-                 weights=[], license="bsd", format_version="0.3.0",
+                 weights=[], license="bsd", format_version="0.3.1",
                  language="python", framework="tensorflow", config = None):
         self.name = name
-        self.desc = desc
-        self.cite = cite
+        self.description = desc
+        self.timestamp = datetime.now().isoformat()
+        if cite is not None:
+            self.cite = cite
         self.authors = authors
         self.documentation = documentation
+        self.git_repo = "https://github.com/CSBDeep/CSBDeep"
         self.tags = tags
         self.license = license
         self.format_version = format_version
         self.language = language
         self.framework = framework
+        self.dependencies = dependencies
+        self.covers = covers
         self.sample_input = sample_input
         self.sample_output = sample_output
         self.inputs = inputs
         self.outputs = outputs
         self.weights = weights
-        self.config = config
+        if config is not None:
+            self.config = config
 
 
 def modelzoo_export(tf_model, folder_path, modelzoo_data, sample_input=None, sample_output=None,
                     zip_name=None):
     export_SavedModel(tf_model, folder_path)
-    modelzoo_weight = ModelZooWeight("tensorflow_keras_CARE", './variables/variables', str(zip_name))
+    modelzoo_weight = ModelZooWeight("tensorflow_saved_model_bundle", './variables/variables', str(zip_name))
     modelzoo_data.weights = [modelzoo_weight]
     if zip_name is None:
         zip_name = folder_path / 'export.bioimage.io.model.zip'
     else:
         zip_name = Path(zip_name)
+    input_file = folder_path / 'sample_input.tif'
+    output_file = folder_path / 'sample_output.tif'
+    imsave(input_file, sample_input)
+    imsave(output_file, sample_output)
+    modelzoo_data.test_inputs = [input_file]
+    modelzoo_data.test_outputs = [output_file]
+
     yml_file = folder_path / "model.yml"
     yaml = YAML(typ='rt')
     yaml.default_flow_style = False
     with open(yml_file, 'w', encoding='UTF-8') as outfile:
         yaml.dump(modelzoo_data, outfile)
 
-    input_file = folder_path / 'sample_input.tif'
-    output_file = folder_path / 'sample_output.tif'
-    imsave(input_file, sample_input)
-    imsave(output_file, sample_output)
 
     with ZipFile(zip_name, 'a') as myzip:
         myzip.write(yml_file, arcname=os.path.basename(yml_file))

--- a/csbdeep/io/modelzoo.py
+++ b/csbdeep/io/modelzoo.py
@@ -22,48 +22,48 @@ class Postprocessing(dict):
 
 class ZeroMeanUnitVariance(Preprocessing):
     def __init__(self, mode, axes, mean, std):
-        self.name = "zero_mean_unit_variance"
-        self.kwargs = {}
-        self.kwargs.mode = mode
-        self.kwargs.axes = axes
+        self["name"] = "zero_mean_unit_variance"
+        self["kwargs"] = {}
+        self["kwargs"]["mode"] = mode
+        self["kwargs"]["axes"] = axes
         if (mode == "fixed"):
-            self.kwargs.mean = mean
-            self.kwargs.std = std
+            self["kwargs"]["mean"] = mean
+            self["kwargs"]["std"] = std
 
 
 class ScaleLinear(Postprocessing):
     def __init__(self, gain, axes, offset):
-        self.name = "scale_linear"
-        self.kwargs = {}
-        self.kwargs.gain = gain
-        self.kwargs.offset = offset
-        self.kwargs.axes = axes
+        self["name"] = "scale_linear"
+        self["kwargs"] = {}
+        self["kwargs"]["gain"] = gain
+        self["kwargs"]["offset"] = offset
+        self["kwargs"]["axes"] = axes
 
 
 class ModelZooInput(dict):
 
     def __init__(self, name, axes, data_type, data_range, halo, min, step,
                  preprocessing):
-        self.name = name
-        self.axes = axes
-        self.data_type = data_type
-        self.data_range = data_range
-        self.halo = halo
-        self.shape = {}
-        self.shape.min = min
-        self.shape.step = step
-        self.preprocessing = preprocessing
+        self["name"] = name
+        self["axes"] = axes
+        self["data_type"] = data_type
+        self["data_range"] = data_range
+        self["halo"] = halo
+        self["shape"] = {}
+        self["shape"]["min"] = min
+        self["shape"]["step"] = step
+        self["preprocessing"] = preprocessing
 
 
 class ModelZooOutput(dict):
     def __init__(self, name, axes, offset, scale, reference_input, postprocessing):
-        self.name = name
-        self.axes = axes
-        self.shape = {}
-        self.shape.offset = offset
-        self.shape.scale = scale
-        self.shape.reference_input = reference_input
-        self.postprocessing = postprocessing
+        self["name"] = name
+        self["axes"] = axes
+        self["shape"] = {}
+        self["shape"]["offset"] = offset
+        self["shape"]["scale"] = scale
+        self["shape"]["reference_input"] = reference_input
+        self["postprocessing"] = postprocessing
 
 
 class ModelZooWeight(dict):

--- a/csbdeep/io/modelzoo.py
+++ b/csbdeep/io/modelzoo.py
@@ -1,0 +1,127 @@
+import os
+from datetime import datetime
+from hashlib import sha256
+from zipfile import ZipFile
+
+from ruamel.yaml import YAML
+from tifffile import imsave
+
+from csbdeep.utils.six import Path
+from csbdeep.utils.tf import export_SavedModel
+
+
+class Preprocessing(dict):
+    def __init__(self):
+        pass
+
+
+class Postprocessing(dict):
+    def __init__(self):
+        pass
+
+
+class ZeroMeanUnitVariance(Preprocessing):
+    def __init__(self, mode: str, axes: str, mean: list[float], std: list[float]):
+        self.name = "Zero_mean_unit_variance"
+        self.kwargs = {}
+        self.kwargs.mode = mode
+        self.kwargs.axes = axes
+        if (mode == "fixed"):
+            self.kwargs.mean = mean
+            self.kwargs.std = std
+
+
+class ScaleLinear(Postprocessing):
+    def __init__(self, mode: str, axes: str):
+        self.name = "Zero_mean_unit_variance"
+        self.kwargs = {}
+        self.kwargs.gain = mode
+        self.kwargs.offset = axes
+
+
+class ModelZooInput(dict):
+
+    def __init__(self, name: str, axes: str, data_type: type, data_range: list, halo: list, min: list, step: list,
+                 preprocessing: Preprocessing):
+        self.name = name
+        self.axes = axes
+        self.data_type = data_type
+        self.data_range = data_range
+        self.halo = halo
+        self.shape = {}
+        self.shape.min = min
+        self.shape.step = step
+        self.preprocessing = preprocessing
+
+
+class ModelZooOutput(dict):
+    def __init__(self, name: str, axes: str, offset: list, scale: list, reference_input: str, postprocessing: dict):
+        self.name = name
+        self.axes = axes
+        self.shape = {}
+        self.shape.offset = offset
+        self.shape.scale = scale
+        self.shape.reference_input = reference_input
+        self.postprocessing = postprocessing
+
+
+class ModelZooWeight(dict):
+    def __init__(self, weight_format: str, source: str, modelfile_name: str):
+        self.weight_format = weight_format
+        self.source = source
+        with open(modelfile_name, "rb") as f:
+            bytes = f.read()
+            self.sha256 = sha256(bytes).hexdigest()
+        self.timestamp = datetime.now().isoformat()
+
+
+class ModelZooBaseData(dict):
+    def __init__(self, name: str, desc: str, cite: list[dict], authors: list[str], documentation: str,
+                 tags: list[str] = None,
+                 sample_input: list[str] = ['./sample_input.tif'], sample_output: list[str] = ['./sample_output.tif'],
+                 inputs: list[ModelZooInput] = [],
+                 outputs: list[ModelZooOutput] = [],
+                 weights: list[ModelZooWeight] = [], license: str = "bsd", format_version: str = "0.3.0",
+                 language: str = "python", framework: str = "tensorflow", config: dict = None):
+        self.name = name
+        self.desc = desc
+        self.cite = cite
+        self.authors = authors
+        self.documentation = documentation
+        self.tags = tags
+        self.license = license
+        self.format_version = format_version
+        self.language = language
+        self.framework = framework
+        self.sample_input = sample_input
+        self.sample_output = sample_output
+        self.inputs = inputs
+        self.outputs = outputs
+        self.weights = weights
+        self.config = config
+
+
+def modelzoo_export(tf_model, folder_path, modelzoo_data: ModelZooBaseData, sample_input=None, sample_output=None,
+                    zip_name=None):
+    export_SavedModel(tf_model, folder_path)
+    if zip_name is None:
+        zip_name = folder_path / 'export.bioimage.io.zip'
+    else:
+        zip_name = Path(zip_name)
+    yml_file = folder_path / "model.yml"
+    yaml = YAML(typ='rt')
+    yaml.default_flow_style = False
+    with open(yml_file, 'w', encoding='UTF-8') as outfile:
+        yaml.dump(modelzoo_data, outfile)
+
+    input_file = folder_path / 'sample_input.tif'
+    output_file = folder_path / 'sample_output.tif'
+    imsave(input_file, sample_input)
+    imsave(output_file, sample_output)
+
+    with ZipFile(zip_name, 'a') as myzip:
+        myzip.write(yml_file, arcname=os.path.basename(yml_file))
+        myzip.write(input_file, arcname=os.path.basename(input_file))
+        myzip.write(output_file, arcname=os.path.basename(output_file))
+
+    print("\nModel exported in BioImage ModelZoo format:\n%s" % str(zip_name.resolve()))

--- a/csbdeep/io/modelzoo.py
+++ b/csbdeep/io/modelzoo.py
@@ -105,7 +105,7 @@ def modelzoo_export(tf_model, folder_path, modelzoo_data: ModelZooBaseData, samp
                     zip_name=None):
     export_SavedModel(tf_model, folder_path)
     if zip_name is None:
-        zip_name = folder_path / 'export.bioimage.io.zip'
+        zip_name = folder_path / 'export.bioimage.io.model.zip'
     else:
         zip_name = Path(zip_name)
     yml_file = folder_path / "model.yml"

--- a/csbdeep/io/modelzoo.py
+++ b/csbdeep/io/modelzoo.py
@@ -104,6 +104,8 @@ class ModelZooBaseData(dict):
 def modelzoo_export(tf_model, folder_path, modelzoo_data, sample_input=None, sample_output=None,
                     zip_name=None):
     export_SavedModel(tf_model, folder_path)
+    modelzoo_weight = ModelZooWeight("tensorflow_keras_CARE", './variables/variables', str(zip_name))
+    modelzoo_data.weights = [modelzoo_weight]
     if zip_name is None:
         zip_name = folder_path / 'export.bioimage.io.model.zip'
     else:

--- a/csbdeep/models/care_standard.py
+++ b/csbdeep/models/care_standard.py
@@ -8,7 +8,8 @@ from six import string_types
 from csbdeep.internals.probability import ProbabilisticPrediction
 from .config import Config
 from .base_model import BaseModel, suppress_without_basedir
-from ..io.modelzoo import ModelZooBaseData, ModelZooWeight, ModelZooInput, ModelZooOutput, modelzoo_export
+from ..io.modelzoo import ModelZooBaseData, ModelZooWeight, ModelZooInput, ModelZooOutput, modelzoo_export, \
+    ZeroMeanUnitVariance, ScaleLinear
 
 from ..utils import _raise, axes_check_and_normalize, axes_dict, move_image_axes
 from ..utils.six import Path
@@ -230,13 +231,43 @@ class CARE(BaseModel):
             min_val = [1, val, val, 0]
         if halo_val is None:
             halo_val = [1, val, val, 0]
-        # TODO preprocessing probabilistic/postprocessing
+        if name is None:
+            name = "CARE standard"
+        if desc is None:
+            desc = "Content-aware restoration (CARE) of (fluorescence) microscopy images, based on deep learning via Keras and TensorFlow"
+        if cite is None:
+            cite = {
+                "text": "Content-aware image restoration: pushing the limits of fluorescence microscopy",
+                "doi": "https://doi.org/10.1038/s41592-018-0216-7"
+            }
+        if authors is None:
+            authors = ["Martin Weigert", "Uwe Schmidt", "Tobias Boothe", "Andreas Müller", "Alexandr Dibrov",
+                   "Akanksha Jain", "Benjamin Wilhelm", "Deborah Schmidt", "Coleman Broaddus","Siân Culley",
+                   "Mauricio Rocha-Martins", "Fabián Segovia-Miranda", "Caren Norden",
+                   "Ricardo Henriques", "Marino Zerial", "Michele Solimena", "Jochen Rink",
+                   "Pavel Tomancak", "Loic Royer", "Florian Jug", "Eugene W. Myers" ]
+        if documentation is None:
+            documentation = "http://csbdeep.bioimagecomputing.com/doc/"
+
+        tags = ["CARE","content aware image restoration", "tensorflow", "unet"]
+        dependencies = "python:setup.py"
+        #TODO: Add a cover image to the repo for linking and adding to the zipfile, maybe move to export method
+        covers = ["./sample_input.tif"]
+
+        #TODO: pre- and post-processing values - where to get them?
+        preprocessing = ZeroMeanUnitVariance(axes=self.config.axes, mode="fixed", mean=0.0, std=0.0)
+        postprocessing = ScaleLinear(axes=self.config.axes, gain=0.0, offset=0.0)
+
+        #TODO: load sample image and add to modelzoo_export arguments
+
         modelzoo_input = ModelZooInput("input", self.config.axes, data_type="float32", data_range=['-inf', 'inf'],
-                                       halo=halo_val, min=min_val, step=step_val)
+                                       halo=halo_val, min=min_val, step=step_val, preprocessing= preprocessing)
         modelzoo_output = ModelZooOutput(self.keras_model.layers[-1].output.name, self.config.axes, scale=scale_val,
-                                         offset=offset_val, reference_input="input")
-        modelzoo = ModelZooBaseData(name, desc, cite, authors, documentation, inputs=[modelzoo_input],
-                                    outputs=[modelzoo_output])
+                                         offset=offset_val, reference_input="input", postprocessing=postprocessing)
+        modelzoo_weight = ModelZooWeight()
+        modelzoo = ModelZooBaseData(name, desc, cite, authors, documentation, tags, dependencies, covers,
+                                    sample_input="", sample_output="",
+                                    inputs=[modelzoo_input], outputs=[modelzoo_output], weights=[modelzoo_weight])
         modelzoo_export(self.keras_model, self.logdir, modelzoo, None, None,
                         str(fname))
         print("\nModel exported in TensorFlow's SavedModel format:\n%s" % str(fname.resolve()))

--- a/csbdeep/models/care_standard.py
+++ b/csbdeep/models/care_standard.py
@@ -200,7 +200,7 @@ class CARE(BaseModel):
 
 
     @suppress_without_basedir(warn=True)
-    def export_TF(self, fname=None, name=None, desc=None, cite=None, authors=None, documentation=None, min_val=None, step_val=None, halo_val=None, scale_val=[1, 1, 1, 1],
+    def export_TF(self, fname=None, authors=None, tags=[], min_val=None, step_val=None, halo_val=None, scale_val=[1, 1, 1, 1],
                   offset_val=[0, 0, 0, 0]):
         """Export neural network via :func:`csbdeep.utils.tf.export_SavedModel`.
 
@@ -231,25 +231,20 @@ class CARE(BaseModel):
             min_val = [1, val, val, 0]
         if halo_val is None:
             halo_val = [1, val, val, 0]
-        if name is None:
-            name = "CARE standard"
-        if desc is None:
-            desc = "Content-aware restoration (CARE) of (fluorescence) microscopy images, based on deep learning via Keras and TensorFlow"
-        if cite is None:
-            cite = {
-                "text": "Content-aware image restoration: pushing the limits of fluorescence microscopy",
-                "doi": "https://doi.org/10.1038/s41592-018-0216-7"
-            }
-        if authors is None:
-            authors = ["Martin Weigert", "Uwe Schmidt", "Tobias Boothe", "Andreas Müller", "Alexandr Dibrov",
-                   "Akanksha Jain", "Benjamin Wilhelm", "Deborah Schmidt", "Coleman Broaddus","Siân Culley",
-                   "Mauricio Rocha-Martins", "Fabián Segovia-Miranda", "Caren Norden",
-                   "Ricardo Henriques", "Marino Zerial", "Michele Solimena", "Jochen Rink",
-                   "Pavel Tomancak", "Loic Royer", "Florian Jug", "Eugene W. Myers" ]
-        if documentation is None:
-            documentation = "http://csbdeep.bioimagecomputing.com/doc/"
+        name = "CARE standard"
+        desc = "Content-aware restoration (CARE) of (fluorescence) microscopy images, based on deep learning via Keras and TensorFlow"
+        cite = {
+            "text": "Content-aware image restoration: pushing the limits of fluorescence microscopy",
+            "doi": "https://doi.org/10.1038/s41592-018-0216-7"
+        }
+        model_authors = ["Martin Weigert", "Uwe Schmidt", "Tobias Boothe", "Andreas Müller", "Alexandr Dibrov",
+               "Akanksha Jain", "Benjamin Wilhelm", "Deborah Schmidt", "Coleman Broaddus", "Siân Culley",
+               "Mauricio Rocha-Martins", "Fabián Segovia-Miranda", "Caren Norden",
+               "Ricardo Henriques", "Marino Zerial", "Michele Solimena", "Jochen Rink",
+               "Pavel Tomancak", "Loic Royer", "Florian Jug", "Eugene W. Myers"]
+        documentation = "http://csbdeep.bioimagecomputing.com/doc/"
 
-        tags = ["CARE","content aware image restoration", "tensorflow", "unet"]
+        model_tags = ["CARE", "content aware image restoration", "tensorflow", "unet"]
         dependencies = "python:setup.py"
         #TODO: Add a cover image to the repo for linking and adding to the zipfile, maybe move to export method
         covers = ["./sample_input.tif"]
@@ -264,12 +259,16 @@ class CARE(BaseModel):
                                        halo=halo_val, min=min_val, step=step_val, preprocessing= preprocessing)
         modelzoo_output = ModelZooOutput(self.keras_model.layers[-1].output.name, self.config.axes, scale=scale_val,
                                          offset=offset_val, reference_input="input", postprocessing=postprocessing)
-        modelzoo_weight = ModelZooWeight()
-        modelzoo = ModelZooBaseData(name, desc, cite, authors, documentation, tags, dependencies, covers,
+        modelzoo_weight = ModelZooWeight(weight_format="tensorflow_saved_model_bundle",
+                                         modelfile_name=str(fname) + "/tf_saved_model_bundle.zip",
+                                         authors=authors, tag=tags, tensorflowversion=tf.version,
+                                         source="tf_saved_model_bundle.zip")
+        modelzoo = ModelZooBaseData(name, desc, cite, model_authors, documentation, model_tags, dependencies, covers,
                                     sample_input="", sample_output="",
                                     inputs=[modelzoo_input], outputs=[modelzoo_output], weights=[modelzoo_weight])
         modelzoo_export(self.keras_model, self.logdir, modelzoo, None, None,
                         str(fname))
+
         print("\nModel exported in TensorFlow's SavedModel format:\n%s" % str(fname.resolve()))
 
 

--- a/csbdeep/utils/tf.py
+++ b/csbdeep/utils/tf.py
@@ -159,8 +159,8 @@ def export_SavedModel(model, outpath, meta={}, format='zip'):
                 _model.set_weights(weights)
                 _export(_model)
 
-        if meta is not None and len(meta) > 0:
-            save_json(meta, os.path.join(dirname,'meta.json'))
+    ##    if meta is not None and len(meta) > 0:
+    ##        save_json(meta, os.path.join(dirname,'meta.json'))
 
 
     ## checks

--- a/csbdeep/utils/tf.py
+++ b/csbdeep/utils/tf.py
@@ -159,8 +159,8 @@ def export_SavedModel(model, outpath, meta={}, format='zip'):
                 _model.set_weights(weights)
                 _export(_model)
 
-    ##    if meta is not None and len(meta) > 0:
-    ##        save_json(meta, os.path.join(dirname,'meta.json'))
+        if meta is not None and len(meta) > 0:
+            save_json(meta, os.path.join(dirname,'meta.json'))
 
 
     ## checks

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name='csbdeep',
           "tqdm",
           "pathlib2; python_version<'3'",
           "backports.tempfile; python_version<'3.4'",
+          "ruamel.yaml"
       ],
 
       entry_points={


### PR DESCRIPTION
This is a basic API to export the keras model in addition to the current 0.3.0 BioImage.io Modelzoo spec model.
This is currently done in N2V, but should be included in CSBDeep to be available for other training schemes. 
The Modelzoo spec is in this PR matches the support in Fiji and supports the latest features there.