### PR TITLE
feature pyramid network block

### DIFF
--- a/csbdeep/internals/blocks.py
+++ b/csbdeep/internals/blocks.py
@@ -195,11 +195,12 @@ def fpn_block(n_depth=3,
     similar to a unet encoder, just that for each resolution level in the decoder path a head with `pyramid_filters` channels will be created which at the end will be concatenated
 
     """
+    n_depth >= 2 or _raise(ValueError('required: n_depth >= 2'))
     if len(pool) != len(kernel_size):
         raise ValueError('kernel and pool sizes must match.')
     n_dim = len(kernel_size)
     if n_dim not in (2,3):
-        raise ValueError('unet_block only 2d or 3d.')
+        raise ValueError('fpn_block only 2d or 3d.')
 
     conv_block = conv_block2  if n_dim == 2 else conv_block3
     pooling    = MaxPooling2D if n_dim == 2 else MaxPooling3D
@@ -228,7 +229,7 @@ def fpn_block(n_depth=3,
         
         # ...and up with skip layers
         for n in reversed(range(n_depth)):
-            layer = resnet_block(n_filter_base * 2 ** max(0, n_depth - 1),
+            layer = resnet_block(n_filter_base * 2 ** max(0, n - 1),
                                  kernel_size, pool=(1,)*len(kernel_size),
                                  n_conv_per_block=n_conv_per_depth,activation=activation,
                                  batch_norm=batch_norm)(layer)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -3,9 +3,23 @@ from csbdeep.utils.tf import keras_import
 K = keras_import('backend')
 Input = keras_import('layers', 'Input')
 Model = keras_import('models', 'Model')
-
 from csbdeep.internals.blocks import unet_block, resnet_block, fpn_block
 
+
+def compute_receptive_field(model, ndim):
+    # TODO: good enough?
+    img_size = (128,)*ndim
+    # print(img_size)
+    mid = tuple(s//2 for s in img_size)
+    x = np.zeros((1,)+img_size+(1,), dtype=np.float32)
+    z = np.zeros_like(x)
+    x[(0,)+mid+(slice(None),)] = 1
+    y  = model.predict(x)[0][...,0]
+    y0 = model.predict(z)[0][...,0]
+    ind = np.where(np.abs(y-y0)>0)
+    return [(m-np.min(i), np.max(i)-m) for (m,i) in zip(mid,ind)]
+
+    
 
 def test_blocks():
     for ndim in (2,3):
@@ -13,20 +27,21 @@ def test_blocks():
 
         x = np.zeros((1,)+shape)
 
-        inp = Input(shape)
+        inp = Input((None,)*ndim+(1,))
 
-        block_kwargs = dict(kernel_size=(3,)*ndim, pool=(2,)*ndim)
+        block_kwargs = dict(n_depth=3, kernel_size=(3,)*ndim, pool=(2,)*ndim)
 
         for block in (unet_block, fpn_block):
+            print(f"{block} and {ndim} dims")
             out = block(**block_kwargs)(inp)
             model = Model(inp, out)
+            print(f"receptive field: {compute_receptive_field(model, ndim)}")
             y = model.predict(x)
-            print(block, y.shape)
 
 
 
 if __name__ == '__main__':
 
-    test_blocks()
+    model = test_blocks()
 
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,32 @@
+import numpy as np
+from csbdeep.utils.tf import keras_import
+K = keras_import('backend')
+Input = keras_import('layers', 'Input')
+Model = keras_import('models', 'Model')
+
+from csbdeep.internals.blocks import unet_block, resnet_block, fpn_block
+
+
+def test_blocks():
+    for ndim in (2,3):
+        shape = (64,)*ndim+(1,)
+
+        x = np.zeros((1,)+shape)
+
+        inp = Input(shape)
+
+        block_kwargs = dict(kernel_size=(3,)*ndim, pool=(2,)*ndim)
+
+        for block in (unet_block, fpn_block):
+            out = block(**block_kwargs)(inp)
+            model = Model(inp, out)
+            y = model.predict(x)
+            print(block, y.shape)
+
+
+
+if __name__ == '__main__':
+
+    test_blocks()
+
+


### PR DESCRIPTION
Introduces a simple feature pyramid block `fpn_block`, which is similar to the `unet_block`, just that for each resolution level in the decoder path a head with `pyramid_filters` channels will be created which at the end will be concatenated


