### PR TITLE
Allow additional parsing of loaded config dicts

### DIFF
--- a/csbdeep/models/base_model.py
+++ b/csbdeep/models/base_model.py
@@ -137,7 +137,7 @@ class BaseModel(object):
         if self.config is None:
             if config_file.exists():
                 config_dict = load_json(str(config_file))
-                config_dict = self._config_class.parse_loaded_config(config_dict)
+                config_dict = self._config_class.update_loaded_config(config_dict)
                 self.config = self._config_class(**config_dict)
                 if not self.config.is_valid():
                     invalid_attr = self.config.is_valid(True)[1]

--- a/csbdeep/models/base_model.py
+++ b/csbdeep/models/base_model.py
@@ -137,6 +137,7 @@ class BaseModel(object):
         if self.config is None:
             if config_file.exists():
                 config_dict = load_json(str(config_file))
+                config_dict = self._config_class.parse_loaded_config(config_dict)
                 self.config = self._config_class(**config_dict)
                 if not self.config.is_valid():
                     invalid_attr = self.config.is_valid(True)[1]

--- a/csbdeep/models/config.py
+++ b/csbdeep/models/config.py
@@ -76,24 +76,23 @@ class BaseConfig(argparse.Namespace):
             setattr(self, k, kwargs[k])
 
     @classmethod
-    def parse_loaded_config(cls, conf):
-        """Called when loading a model from file
+    def update_loaded_config(cls, config):
+        """Called by model to update loaded config dictionary before config object is created
 
-        Can be used to provide config specific parsing of loaded 
-        parameters, e.g. to ensure backwards compatibility when introducing 
-        new parameters
+        Can be used to modify or introduce/delete parameters, e.g. to ensure
+        backwards compatibility after new parameters have been introduced.
 
         Parameters
         ----------
-        param : dict
-            dictionary of config arguments as loaded from config.json 
+        config : dict
+            dictionary of config parameters loaded from file
 
         Returns
         -------
-        updated_params: dict
-            a updated version of the parameters 
+        updated_config: dict
+            an updated version of the config parameter dictionary
         """
-        return conf
+        return config
 
 
 

--- a/csbdeep/models/config.py
+++ b/csbdeep/models/config.py
@@ -75,6 +75,25 @@ class BaseConfig(argparse.Namespace):
         for k in kwargs:
             setattr(self, k, kwargs[k])
 
+    @classmethod
+    def parse_loaded_config(cls, conf):
+        """Called when loading a model from file
+
+        Can be used to provide config specific parsing of loaded 
+        parameters, e.g. to ensure backwards compatibility when introducing 
+        new parameters
+
+        Parameters
+        ----------
+        param : dict
+            dictionary of config arguments as loaded from config.json 
+
+        Returns
+        -------
+        updated_params: dict
+            a updated version of the parameters 
+        """
+        return conf
 
 
 

--- a/csbdeep/models/pretrained.py
+++ b/csbdeep/models/pretrained.py
@@ -25,6 +25,11 @@ def clear_models_and_aliases(*cls):
 
 
 def register_model(cls, key, url, hash):
+    """ Example: 
+    
+    register_model(StarDist2D,   'my_great_model', 'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_versatile_fluo.zip', md5sum_as_astring)
+
+    """
     # key must be a valid file/folder name in the file system
     models = _MODELS.setdefault(cls,OrderedDict())
     key not in models or warn("re-registering model '%s' (was already registered for '%s')" % (key, cls.__name__))


### PR DESCRIPTION
Adds a classmethod `BaseConfig.parse_loaded_config` that is called when loading a model.

Can be used to provide config specific parsing of loaded  parameters, e.g. to ensure backwards compatibility when introducing new parameters
