### PR TITLE
Remove specifying TF version from the notebook

### DIFF
--- a/extras/care_example_denoising_upsampling_2D_colab.ipynb
+++ b/extras/care_example_denoising_upsampling_2D_colab.ipynb
@@ -53,19 +53,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "AyhNmEz7ACTv"
-   },
-   "outputs": [],
-   "source": [
-    "%tensorflow_version 1.x"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",


### PR DESCRIPTION
Hi.
Remove `%tensorflow_version 1.x` from [care_example_denoising_upsampling_2D_colab](https://colab.research.google.com/github/CSBDeep/CSBDeep/blob/master/extras/care_example_denoising_upsampling_2D_colab.ipynb) notebook since it's no longer supported in colab.

The notebook runs perfectly as is though.